### PR TITLE
[FEATURE] Add Docker support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "typo3-ter/solr": "5.1.0",
     "pixelant/pxa-form-enhancement": "1.0.1"
   },
+  "require-dev": {
+    "lauri/dockert3kit": "~2.2.0"
+  },
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",

--- a/typo3conf/AdditionalConfiguration.php
+++ b/typo3conf/AdditionalConfiguration.php
@@ -19,7 +19,17 @@ switch (\TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext()) {
 		// Will then appear in http://localhost:1080/ (mailcatcher) and http://localhost:28778/ (logio)
 		// Page will load noticably slow when systemLog to "mail" is enabled and a lot of errors occurs.
 		// $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLog'] = 'mail,dummy@t3kit.com;error_log';
-
+	break;
+	case 'Development/Docker':
+		// SetEnv TYPO3_CONTEXT Development
+		$GLOBALS['TYPO3_CONF_VARS']['DB']['host'] = 'db';
+		$GLOBALS['TYPO3_CONF_VARS']['BE']['debug'] = TRUE;
+		$GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = FALSE;
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 1;
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] = '*';
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] = 'Docker :: t3kit :: TYPO3';
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['sqlDebug'] = 1;
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['clearCacheSystem'] = TRUE;
 	break;
 	case 'Development':
 		// SetEnv TYPO3_CONTEXT Development

--- a/typo3conf/LocalConfiguration.php
+++ b/typo3conf/LocalConfiguration.php
@@ -106,7 +106,7 @@ return [
         'exceptionalErrors' => 28674,
         'isInitialDatabaseImportDone' => true,
         'isInitialInstallationInProgress' => false,
-        'sitename' => 'TYPO3 TYPOkit',
+        'sitename' => 'TYPO3 T3kit',
         'sqlDebug' => 0,
         'systemLocale' => 'sv_SE.UTF-8',
         'systemLogLevel' => 2,


### PR DESCRIPTION
Adds the Docker wrapper to be used with t3kit_docker and additional
configurations for docker development environment.

This pull request will add DockerT3kit wrapper package to vendor folder in  it is quite lightweight. It is also only required in the development environment. So it should not create problems for Vagrant users or production environments.

A small streamlining for site naming configuration is provided.
